### PR TITLE
Add GEPTomic rating to standings

### DIFF
--- a/netlify/functions/standings.js
+++ b/netlify/functions/standings.js
@@ -38,7 +38,8 @@ export default async (req) => {
     jp:0,
     pj:0,
     pg:0,
-    pp:0
+    pp:0,
+    geptomic:4
   }));
 
   // Parejas
@@ -50,6 +51,62 @@ export default async (req) => {
     const aWins = sa>sb, bWins = sb>sa;
     const A = [m.a1,m.a2].filter(Boolean);
     const B = [m.b1,m.b2].filter(Boolean);
+
+    // ensure pair objects exist
+    let pairA=null, pairB=null;
+    if (A.length===2) {
+      const k = pairKey(A[0],A[1]);
+      if (!pairs.has(k)) {
+        const p1=pMap.get(A[0])||{}, p2=pMap.get(A[1])||{};
+        pairs.set(k, { key:k,
+          a:A[0], b:A[1],
+          name:`${p1.name||'?'} + ${p2.name||'?'}`,
+          photos:[p1.photo_base64||'', p2.photo_base64||''],
+          puntos:0, jg:0, jp:0, pj:0, pg:0, pp:0,
+          geptomic:4
+        });
+      }
+      pairA = pairs.get(k);
+    }
+    if (B.length===2) {
+      const k = pairKey(B[0],B[1]);
+      if (!pairs.has(k)) {
+        const p1=pMap.get(B[0])||{}, p2=pMap.get(B[1])||{};
+        pairs.set(k, { key:k,
+          a:B[0], b:B[1],
+          name:`${p1.name||'?'} + ${p2.name||'?'}`,
+          photos:[p1.photo_base64||'', p2.photo_base64||''],
+          puntos:0, jg:0, jp:0, pj:0, pg:0, pp:0,
+          geptomic:4
+        });
+      }
+      pairB = pairs.get(k);
+    }
+
+    // Elo rating update for individuals
+    if (A.length && B.length) {
+      const ratingA = A.reduce((s,id)=>s+ind.get(id).geptomic,0)/A.length;
+      const ratingB = B.reduce((s,id)=>s+ind.get(id).geptomic,0)/B.length;
+      const expA = 1/(1+10**((ratingB-ratingA)/5));
+      const expB = 1 - expA;
+      const scoreA = aWins ? 1 : 0;
+      const scoreB = 1 - scoreA;
+      A.forEach(id=>{ ind.get(id).geptomic += (scoreA - expA); });
+      B.forEach(id=>{ ind.get(id).geptomic += (scoreB - expB); });
+    }
+
+    // Elo rating update for pairs
+    if (pairA && pairB) {
+      const ratingA = pairA.geptomic;
+      const ratingB = pairB.geptomic;
+      const expA = 1/(1+10**((ratingB-ratingA)/5));
+      const expB = 1 - expA;
+      const scoreA = aWins ? 1 : 0;
+      const scoreB = 1 - scoreA;
+      pairA.geptomic += (scoreA - expA);
+      pairB.geptomic += (scoreB - expB);
+    }
+
     // PJ
     A.forEach(id=>{ if(ind.has(id)) ind.get(id).pj++; });
     B.forEach(id=>{ if(ind.has(id)) ind.get(id).pj++; });
@@ -70,44 +127,22 @@ export default async (req) => {
       r.jp += ga;
     });
 
-    // Parejas
-    if (A.length===2) {
-      const k = pairKey(A[0],A[1]);
-      if (!pairs.has(k)) {
-        const p1=pMap.get(A[0])||{}, p2=pMap.get(A[1])||{};
-        pairs.set(k, { key:k,
-          a:A[0], b:A[1],
-          name:`${p1.name||'?'} + ${p2.name||'?'}`,
-          photos:[p1.photo_base64||'', p2.photo_base64||''],
-          puntos:0, jg:0, jp:0, pj:0, pg:0, pp:0
-        });
-      }
-      const row=pairs.get(k);
-      row.pj++;
-      row.puntos+=sa;
-      row.jg+=ga;
-      row.jp+=gb;
-      if (aWins) row.pg++;
-      else if (bWins) row.pp++;
+    // Parejas stats
+    if (pairA) {
+      pairA.pj++;
+      pairA.puntos+=sa;
+      pairA.jg+=ga;
+      pairA.jp+=gb;
+      if (aWins) pairA.pg++;
+      else if (bWins) pairA.pp++;
     }
-    if (B.length===2) {
-      const k = pairKey(B[0],B[1]);
-      if (!pairs.has(k)) {
-        const p1=pMap.get(B[0])||{}, p2=pMap.get(B[1])||{};
-        pairs.set(k, { key:k,
-          a:B[0], b:B[1],
-          name:`${p1.name||'?'} + ${p2.name||'?'}`,
-          photos:[p1.photo_base64||'', p2.photo_base64||''],
-          puntos:0, jg:0, jp:0, pj:0, pg:0, pp:0
-        });
-      }
-      const row=pairs.get(k);
-      row.pj++;
-      row.puntos+=sb;
-      row.jg+=gb;
-      row.jp+=ga;
-      if (bWins) row.pg++;
-      else if (aWins) row.pp++;
+    if (pairB) {
+      pairB.pj++;
+      pairB.puntos+=sb;
+      pairB.jg+=gb;
+      pairB.jp+=ga;
+      if (bWins) pairB.pg++;
+      else if (aWins) pairB.pp++;
     }
   }
 
@@ -119,7 +154,8 @@ export default async (req) => {
       b.pg - a.pg ||
       a.pp - b.pp ||
       a.name.localeCompare(b.name)
-    );
+    )
+    .map(r=>({ ...r, dif:r.jg - r.jp, geptomic:+r.geptomic.toFixed(2) }));
   const parejas = Array.from(pairs.values())
     .sort((a,b)=>
       b.puntos - a.puntos ||
@@ -128,7 +164,8 @@ export default async (req) => {
       b.pg - a.pg ||
       a.pp - b.pp ||
       a.name.localeCompare(b.name)
-    );
+    )
+    .map(r=>({ ...r, dif:r.jg - r.jp, geptomic:+r.geptomic.toFixed(2) }));
 
   return json(req, { individual, parejas });
 }

--- a/public/index.html
+++ b/public/index.html
@@ -138,6 +138,7 @@
                <th class="px-4 py-3 text-center">JG</th>
                <th class="px-4 py-3 text-center">JP</th>
                <th class="px-4 py-3 text-center">Dif</th>
+               <th class="px-4 py-3 text-center">GEPTomic</th>
              </tr></thead>`
           : `<thead class="bg-neutral-50"><tr>
                <th class="px-4 py-3 text-left">#</th>
@@ -149,6 +150,7 @@
                <th class="px-4 py-3 text-center">JG</th>
                <th class="px-4 py-3 text-center">JP</th>
                <th class="px-4 py-3 text-center">Dif</th>
+               <th class="px-4 py-3 text-center">GEPTomic</th>
              </tr></thead>`;
 
         const tbody = document.createElement('tbody');
@@ -165,6 +167,7 @@
                  <td class="px-4 py-3 text-center">${r.jg}</td>
                  <td class="px-4 py-3 text-center">${r.jp}</td>
                  <td class="px-4 py-3 text-center font-semibold ${r.jg - r.jp >= 0 ? 'text-green-600' : 'text-red-600'}">${r.jg - r.jp >= 0 ? '+' : ''}${r.jg - r.jp}</td>
+                 <td class="px-4 py-3 text-center">${r.geptomic}</td>
                </tr>`
             ));
           }else{
@@ -183,6 +186,7 @@
                  <td class="px-4 py-3 text-center">${r.jg}</td>
                  <td class="px-4 py-3 text-center">${r.jp}</td>
                  <td class="px-4 py-3 text-center font-semibold ${r.jg - r.jp >= 0 ? 'text-green-600' : 'text-red-600'}">${r.jg - r.jp >= 0 ? '+' : ''}${r.jg - r.jp}</td>
+                 <td class="px-4 py-3 text-center">${r.geptomic}</td>
                </tr>`
             ));
           }


### PR DESCRIPTION
## Summary
- add GEPTomic Elo-style rating for players and pairs starting from 4 points
- expose dif and GEPTomic fields in individual and pair standings
- display GEPTomic column in standings tables

## Testing
- `node --check netlify/functions/standings.js`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c831bba0148328aa64b11bf4c1838a