### PR TITLE
Improve API key parsing flexibility

### DIFF
--- a/netlify/functions/_common/db.js
+++ b/netlify/functions/_common/db.js
@@ -8,12 +8,66 @@ neonConfig.webSocketConstructor = ws;
 const CONN = process.env.NETLIFY_DATABASE_URL || process.env.DATABASE_URL;
 export const sql = neon(CONN);
 
+function normalizeKey(value) {
+  return (value || '')
+    .trim()
+    .replace(/^['"]+/, '')
+    .replace(/['"]+$/, '');
+}
+
+function findCaseInsensitive(obj, ...names) {
+  if (!obj || typeof obj !== 'object') return '';
+  const lowerNames = names.map((n) => n.toLowerCase());
+  for (const [key, value] of Object.entries(obj)) {
+    if (lowerNames.includes(String(key || '').toLowerCase())) {
+      if (Array.isArray(value)) return value[0] || '';
+      return value;
+    }
+  }
+  return '';
+}
+
 // Valida clave de edición
 export function requireKey(event) {
-  const want = process.env.API_SHARED_KEY || '';
-  if (!want) return; // sin clave configurada => libre (para pruebas)
-  const got = event.headers['x-api-key'] || event.headers['X-Api-Key'];
-  if (got !== want) {
+  const raw = process.env.API_SHARED_KEY || '';
+  const candidates = raw
+    .split(/[,;\n\r]/)
+    .map(normalizeKey)
+    .filter(Boolean);
+
+  if (!candidates.length) return; // sin clave configurada => libre (para pruebas)
+
+  let provided = '';
+
+  provided = normalizeKey(findCaseInsensitive(event?.headers, 'x-api-key'));
+
+  if (!provided && event?.queryStringParameters) {
+    provided = normalizeKey(
+      findCaseInsensitive(event.queryStringParameters, 'key', 'api_key', 'apiKey')
+    );
+  }
+
+  if (!provided && event?.multiValueQueryStringParameters) {
+    provided = normalizeKey(
+      findCaseInsensitive(event.multiValueQueryStringParameters, 'key', 'api_key', 'apiKey')
+    );
+  }
+
+  if (!provided && typeof event?.body === 'string' && event.body.trim()) {
+    try {
+      const parsed = JSON.parse(event.body);
+      provided = normalizeKey(findCaseInsensitive(parsed, 'key', 'api_key', 'apiKey'));
+    } catch (err) {
+      // cuerpo no JSON, ignorar
+    }
+  }
+
+  if (!provided && typeof event?.rawQuery === 'string') {
+    const rawParams = new URLSearchParams(event.rawQuery);
+    provided = normalizeKey(rawParams.get('key') || rawParams.get('api_key') || rawParams.get('apiKey'));
+  }
+
+  if (!candidates.includes(provided)) {
     const err = new Error('forbidden');
     err.statusCode = 403;
     throw err;

--- a/netlify/functions/_common/email.js
+++ b/netlify/functions/_common/email.js
@@ -1,0 +1,337 @@
+import net from 'node:net';
+import tls from 'node:tls';
+import os from 'node:os';
+import { randomUUID } from 'node:crypto';
+
+const DEFAULT_TIMEOUT = 15000;
+
+const toArray = (val) => {
+  if (!val) return [];
+  return Array.isArray(val) ? val.filter(Boolean) : String(val).split(',').map(v=>v.trim()).filter(Boolean);
+};
+
+const encodeSubject = (str = '') => {
+  if (!/[\u0080-\uFFFF]/.test(str)) return str;
+  const b64 = Buffer.from(str, 'utf8').toString('base64');
+  return `=?UTF-8?B?${b64}?=`;
+};
+
+const escapeAddress = (addr) => addr.includes('<') ? addr : `<${addr}>`;
+
+const encodeBase64Lines = (input) => {
+  const b64 = Buffer.from(input, typeof input === 'string' ? 'utf8' : undefined).toString('base64');
+  return b64.replace(/.{1,76}/g, (m) => m + '\r\n').trim();
+};
+
+const foldLine = (line) => {
+  const max = 75;
+  if (Buffer.byteLength(line, 'utf8') <= max) return line;
+  const bytes = Buffer.from(line, 'utf8');
+  let out = '';
+  for (let i = 0; i < bytes.length;) {
+    const chunk = bytes.subarray(i, i + max);
+    out += chunk.toString('utf8');
+    i += chunk.length;
+    if (i < bytes.length) out += '\r\n ';
+  }
+  return out;
+};
+
+const escapeICSText = (str = '') =>
+  str
+    .replace(/\\/g, '\\\\')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/,/g, '\\,')
+    .replace(/;/g, '\\;');
+
+export const formatICS = ({
+  id,
+  summary,
+  description,
+  location,
+  start,
+  end,
+  organizer,
+  attendees = [],
+}) => {
+  const formatDT = (d) => {
+    const iso = (d instanceof Date ? d : new Date(d || Date.now())).toISOString().replace(/[-:]/g, '').replace(/\.\d{3}/, '');
+    return iso.endsWith('Z') ? iso : iso + 'Z';
+  };
+  const lines = [
+    'BEGIN:VCALENDAR',
+    'PRODID:-//GEP Padel//Matches//ES',
+    'VERSION:2.0',
+    'CALSCALE:GREGORIAN',
+    'METHOD:REQUEST',
+    'BEGIN:VEVENT',
+    `UID:${id || randomUUID()}@geppadel`,
+    `DTSTAMP:${formatDT(new Date())}`,
+    `DTSTART:${formatDT(start)}`,
+    `DTEND:${formatDT(end)}`,
+    `SUMMARY:${escapeICSText(summary || 'Partido GEP Padel')}`,
+  ];
+  if (description) lines.push(`DESCRIPTION:${escapeICSText(description)}`);
+  if (location) lines.push(`LOCATION:${escapeICSText(location)}`);
+  if (organizer) lines.push(`ORGANIZER;CN=${escapeICSText(organizer.name || organizer.email || '')}:mailto:${organizer.email}`);
+  attendees.filter(a=>a && a.email).forEach((a) => {
+    const cn = escapeICSText(a.name || a.email);
+    lines.push(`ATTENDEE;CN=${cn};RSVP=FALSE:mailto:${a.email}`);
+  });
+  lines.push('END:VEVENT', 'END:VCALENDAR');
+  return lines.map(foldLine).join('\r\n');
+};
+
+class SMTPClient {
+  constructor(opts) {
+    this.host = opts.host;
+    this.port = opts.port;
+    this.secure = !!opts.secure;
+    this.user = opts.user || '';
+    this.pass = opts.pass || '';
+    this.requireTLS = opts.requireTLS;
+    this.rejectUnauthorized = opts.rejectUnauthorized;
+    this.timeout = opts.timeout || DEFAULT_TIMEOUT;
+    this.clientName = opts.clientName || os.hostname() || 'localhost';
+    this.socket = null;
+    this.features = {};
+  }
+
+  async connect() {
+    const create = this.secure ? tls.connect : net.connect;
+    const socket = create.call(null, {
+      host: this.host,
+      port: this.port,
+      servername: this.host,
+      rejectUnauthorized: this.rejectUnauthorized,
+    });
+    this.socket = socket;
+    socket.setTimeout(this.timeout, () => {
+      socket.destroy(new Error('SMTP connection timeout'));
+    });
+    await new Promise((resolve, reject) => {
+      const onError = (err) => { cleanup(); reject(err); };
+      const onReady = () => { cleanup(); resolve(); };
+      const readyEvt = this.secure ? 'secureConnect' : 'connect';
+      const cleanup = () => {
+        socket.removeListener('error', onError);
+        socket.removeListener(readyEvt, onReady);
+      };
+      socket.once('error', onError);
+      socket.once(readyEvt, onReady);
+    });
+    const greet = await this._read();
+    if (greet.code !== 220) throw new Error(`SMTP greet failed: ${greet.message}`);
+  }
+
+  _read() {
+    if (!this.socket) throw new Error('smtp-not-connected');
+    return new Promise((resolve, reject) => {
+      let buffer = '';
+      const socket = this.socket;
+      const onData = (chunk) => {
+        buffer += chunk.toString('utf8');
+        const lines = buffer.split(/\r?\n/).filter(Boolean);
+        if (!lines.length) return;
+        const last = lines[lines.length - 1];
+        const match = last.match(/^(\d{3})([ \-])/);
+        if (match && match[2] === ' ') {
+          cleanup();
+          resolve({ code: Number(match[1]), message: buffer, lines });
+        }
+      };
+      const onError = (err) => { cleanup(); reject(err); };
+      const onClose = () => { cleanup(); reject(new Error('SMTP connection closed')); };
+      const cleanup = () => {
+        socket.off('data', onData);
+        socket.off('error', onError);
+        socket.off('end', onClose);
+        socket.off('close', onClose);
+      };
+      socket.on('data', onData);
+      socket.once('error', onError);
+      socket.once('end', onClose);
+      socket.once('close', onClose);
+    });
+  }
+
+  async _command(cmd, expect) {
+    const socket = this.socket;
+    if (!socket) throw new Error('smtp-not-connected');
+    socket.write(cmd + '\r\n', 'utf8');
+    const res = await this._read();
+    const wants = Array.isArray(expect) ? expect : [expect];
+    if (expect && !wants.includes(res.code)) {
+      throw new Error(`SMTP command failed (${cmd.split(' ')[0]}): ${res.message}`);
+    }
+    return res;
+  }
+
+  async _ehlo() {
+    const res = await this._command(`EHLO ${this.clientName}`, 250);
+    const feats = { auth: [] };
+    res.lines.slice(1).forEach(line => {
+      const txt = line.replace(/^250[- ]/, '').trim();
+      const [verb, ...rest] = txt.split(' ');
+      const key = verb.toUpperCase();
+      if (key === 'AUTH') feats.auth = rest.map(v=>v.trim().toUpperCase());
+      else if (key === 'STARTTLS') feats.starttls = true;
+      feats[key] = rest.join(' ');
+    });
+    this.features = feats;
+  }
+
+  async _startTLS() {
+    if (!this.socket) throw new Error('smtp-not-connected');
+    await this._command('STARTTLS', 220);
+    const secureSocket = tls.connect({
+      socket: this.socket,
+      servername: this.host,
+      rejectUnauthorized: this.rejectUnauthorized,
+    });
+    this.socket = secureSocket;
+    secureSocket.setTimeout(this.timeout, () => {
+      secureSocket.destroy(new Error('SMTP TLS timeout'));
+    });
+    await new Promise((resolve, reject) => {
+      const onError = (err) => { cleanup(); reject(err); };
+      const onReady = () => { cleanup(); resolve(); };
+      const cleanup = () => {
+        secureSocket.removeListener('error', onError);
+        secureSocket.removeListener('secureConnect', onReady);
+      };
+      secureSocket.once('error', onError);
+      secureSocket.once('secureConnect', onReady);
+    });
+    await this._ehlo();
+  }
+
+  async _auth() {
+    if (!this.user) return;
+    const auths = this.features.auth || [];
+    if (auths.includes('PLAIN')) {
+      const payload = Buffer.from(`\0${this.user}\0${this.pass}`, 'utf8').toString('base64');
+      await this._command(`AUTH PLAIN ${payload}`, 235);
+    } else if (auths.includes('LOGIN')) {
+      await this._command('AUTH LOGIN', 334);
+      await this._command(Buffer.from(this.user, 'utf8').toString('base64'), 334);
+      await this._command(Buffer.from(this.pass, 'utf8').toString('base64'), 235);
+    } else {
+      throw new Error('SMTP auth method not supported by server');
+    }
+  }
+
+  async send({ from, recipients, data }) {
+    await this.connect();
+    await this._ehlo();
+    if (!this.secure && this.features.starttls && this.requireTLS !== false) {
+      await this._startTLS();
+    }
+    await this._auth();
+    await this._command(`MAIL FROM:${escapeAddress(from)}`, [250, 251]);
+    for (const rcpt of recipients) {
+      await this._command(`RCPT TO:${escapeAddress(rcpt)}`, [250, 251]);
+    }
+    const socket = this.socket;
+    if (!socket) throw new Error('smtp-not-connected');
+    socket.write('DATA\r\n', 'utf8');
+    const ready = await this._read();
+    if (ready.code !== 354) throw new Error(`SMTP DATA not accepted: ${ready.message}`);
+    const normalized = data.endsWith('\r\n') ? data : data + '\r\n';
+    const safeData = normalized.replace(/\r\n\./g, '\r\n..');
+    socket.write(safeData + '.\r\n', 'utf8');
+    const sent = await this._read();
+    if (sent.code !== 250) throw new Error(`SMTP message rejected: ${sent.message}`);
+    try {
+      await this._command('QUIT', [221, 250]);
+    } catch (_) {
+      /* ignore */
+    }
+    socket.destroy();
+  }
+}
+
+export async function sendMail(options) {
+  const host = process.env.SMTP_HOST || process.env.EMAIL_HOST;
+  if (!host) throw new Error('SMTP_HOST not configured');
+  const port = Number(process.env.SMTP_PORT || 587);
+  const secure = String(process.env.SMTP_SECURE || '').toLowerCase() === 'true' || port === 465;
+  const requireTLS = (process.env.SMTP_REQUIRE_TLS || '').toLowerCase() !== 'false';
+  const rejectUnauthorized = (process.env.SMTP_TLS_REJECT || 'true').toLowerCase() !== 'false';
+  const clientName = process.env.SMTP_CLIENT_NAME || undefined;
+  const user = process.env.SMTP_USER || '';
+  const pass = process.env.SMTP_PASS || '';
+
+  const to = toArray(options.to);
+  const cc = toArray(options.cc);
+  const bcc = toArray(options.bcc);
+  const recipients = [...new Set([...to, ...cc, ...bcc])];
+  if (!recipients.length) throw new Error('No recipients provided');
+
+  const fromAddr = options.from || process.env.SMTP_FROM || process.env.MAIL_FROM || 'julio@gepgroup.es';
+
+  const headers = [];
+  headers.push(`From: ${fromAddr}`);
+  if (to.length) headers.push(`To: ${to.join(', ')}`);
+  if (cc.length) headers.push(`Cc: ${cc.join(', ')}`);
+  headers.push(`Subject: ${encodeSubject(options.subject || '')}`);
+  headers.push(`Date: ${new Date().toUTCString()}`);
+  headers.push(`Message-ID: <${randomUUID()}@${host}>`);
+  headers.push('MIME-Version: 1.0');
+  if (options.replyTo) headers.push(`Reply-To: ${options.replyTo}`);
+
+  const attachments = options.attachments || [];
+  const hasHtml = !!options.html;
+  const hasAlt = hasHtml && options.text;
+  const boundaryMain = attachments.length ? `----=_GEP_${randomUUID()}` : null;
+  const boundaryAlt = hasAlt ? `----=_GEP_ALT_${randomUUID()}` : null;
+
+  let body = '';
+  if (attachments.length) {
+    headers.push(`Content-Type: multipart/mixed; boundary="${boundaryMain}"`);
+    body += `--${boundaryMain}\r\n`;
+    if (hasAlt) {
+      headers.push('');
+      body += `Content-Type: multipart/alternative; boundary="${boundaryAlt}"\r\n\r\n`;
+      body += `--${boundaryAlt}\r\nContent-Type: text/plain; charset="utf-8"\r\nContent-Transfer-Encoding: 8bit\r\n\r\n${options.text || ''}\r\n`;
+      body += `--${boundaryAlt}\r\nContent-Type: text/html; charset="utf-8"\r\nContent-Transfer-Encoding: 8bit\r\n\r\n${options.html}\r\n`;
+      body += `--${boundaryAlt}--\r\n`;
+    } else {
+      body += `Content-Type: ${options.html ? 'text/html' : 'text/plain'}; charset="utf-8"\r\nContent-Transfer-Encoding: 8bit\r\n\r\n${options.html || options.text || ''}\r\n`;
+    }
+    attachments.forEach((att) => {
+      body += `--${boundaryMain}\r\n`;
+      body += `Content-Type: ${att.contentType || 'application/octet-stream'}\r\n`;
+      body += 'Content-Transfer-Encoding: base64\r\n';
+      body += `Content-Disposition: attachment; filename="${att.filename || 'file'}"\r\n\r\n`;
+      body += `${encodeBase64Lines(att.content)}\r\n`;
+    });
+    body += `--${boundaryMain}--`;
+  } else if (hasAlt) {
+    headers.push(`Content-Type: multipart/alternative; boundary="${boundaryAlt}"`);
+    body += `--${boundaryAlt}\r\nContent-Type: text/plain; charset="utf-8"\r\nContent-Transfer-Encoding: 8bit\r\n\r\n${options.text || ''}\r\n`;
+    body += `--${boundaryAlt}\r\nContent-Type: text/html; charset="utf-8"\r\nContent-Transfer-Encoding: 8bit\r\n\r\n${options.html}\r\n`;
+    body += `--${boundaryAlt}--`;
+  } else {
+    headers.push(`Content-Type: ${options.html ? 'text/html' : 'text/plain'}; charset="utf-8"`);
+    headers.push('Content-Transfer-Encoding: 8bit');
+    headers.push('');
+    body += options.html || options.text || '';
+  }
+
+  if (!headers.includes('')) headers.push('');
+  const data = headers.join('\r\n') + (body ? '\r\n' + body : '\r\n');
+
+  const client = new SMTPClient({
+    host,
+    port,
+    secure,
+    user,
+    pass,
+    requireTLS,
+    rejectUnauthorized,
+    clientName,
+  });
+  await client.send({ from: fromAddr, recipients, data });
+}

--- a/netlify/functions/_common/format.js
+++ b/netlify/functions/_common/format.js
@@ -1,0 +1,15 @@
+export const formatDateParts = (iso) => {
+  if (!iso) return { date: 'sin fecha', time: '' };
+  const d = new Date(iso);
+  return {
+    date: d.toLocaleDateString('es-ES', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' }),
+    time: d.toLocaleTimeString('es-ES', { hour: '2-digit', minute: '2-digit' })
+  };
+};
+
+export const formatHumanList = (items = []) => {
+  const filtered = items.filter(Boolean);
+  if (filtered.length <= 1) return filtered.join('');
+  if (filtered.length === 2) return `${filtered[0]} y ${filtered[1]}`;
+  return `${filtered.slice(0, -1).join(', ')} y ${filtered[filtered.length - 1]}`;
+};

--- a/netlify/functions/add-player.js
+++ b/netlify/functions/add-player.js
@@ -9,9 +9,17 @@ export default async (req) => {
   const name = (body.name || '').trim();
   const alias = (body.alias || '').trim();
   const photo = (body.photo_base64 || null);
+  const email = (body.email || '').trim();
   if (!name) return json(req, { error: 'name-required' }, 400);
 
-  const id = (globalThis.crypto && crypto.randomUUID) ? crypto.randomUUID() : String(Date.now());
-  await sql`INSERT INTO players (id, name, alias, photo_base64) VALUES (${id}, ${name}, ${alias || null}, ${photo})`;
-  return json(req, { id, name, alias, photo_base64: photo });
+  const aliasVal = alias || null;
+  const emailVal = email || null;
+  const photoVal = photo || null;
+  const rows = await sql`
+    INSERT INTO players (name, alias, photo_base64, email)
+    VALUES (${name}, ${aliasVal}, ${photoVal}, ${emailVal})
+    RETURNING id, name, alias, photo_base64, email
+  `;
+  const created = rows[0] || { id: null, name, alias: aliasVal, photo_base64: photoVal, email: emailVal };
+  return json(req, created);
 }

--- a/netlify/functions/close-result.js
+++ b/netlify/functions/close-result.js
@@ -42,7 +42,8 @@ export default async (req) => {
       s3a=${sets[2].a}, s3b=${sets[2].b},
       sets_a=${winsA}, sets_b=${winsB},
       finalizado=true,
-      comment=${comment || null}
+      comment=${comment || null},
+      calendar_sent=false
     WHERE id=${id}
   `;
   return json(req, { ok: true, sets, sets_a:winsA, sets_b:winsB });

--- a/netlify/functions/create-match.js
+++ b/netlify/functions/create-match.js
@@ -6,11 +6,18 @@ export default async (req) => {
   if (!requireAuth(req)) return json(req, { error: 'unauthorized' }, 401);
 
   const b = await req.json().catch(()=>({}));
-  const { dateISO, a1, a2, b1, b2, comment } = b;
+  const { dateISO, a1, a2, b1, b2, comment, court_name, court_email } = b;
   if (!a1 || !a2 || !b1 || !b2) return json(req, { error: 'need-4-players' }, 400);
 
-  const id = (globalThis.crypto && crypto.randomUUID) ? crypto.randomUUID() : String(Date.now());
-  await sql`INSERT INTO matches (id, date_iso, a1, a2, b1, b2, comment, finalizado)
-            VALUES (${id}, ${dateISO || null}, ${a1}, ${a2}, ${b1}, ${b2}, ${comment || null}, false)`;
-  return json(req, { id });
+  const courtName = (court_name || '').trim();
+  const courtEmail = (court_email || '').trim();
+  if (!courtName || !courtEmail) return json(req, { error: 'court-required' }, 400);
+
+  const rows = await sql`
+    INSERT INTO matches (date_iso, a1, a2, b1, b2, comment, finalizado, court_name, court_email, reservation_sent, calendar_sent)
+    VALUES (${dateISO || null}, ${a1}, ${a2}, ${b1}, ${b2}, ${comment || null}, false, ${courtName}, ${courtEmail}, false, false)
+    RETURNING id
+  `;
+  const created = rows[0] || { id: null };
+  return json(req, created);
 }

--- a/netlify/functions/delete-match.js
+++ b/netlify/functions/delete-match.js
@@ -1,6 +1,8 @@
 // netlify/functions/delete-match.js
 import { sql } from './_common/db.js';
 import { json, preflight, requireAuth } from './_common/http.js';
+import { sendMail } from './_common/email.js';
+import { formatDateParts, formatHumanList } from './_common/format.js';
 
 export default async (req) => {
   const p = preflight(req); if (p) return p;
@@ -8,6 +10,54 @@ export default async (req) => {
 
   const { id } = await req.json().catch(()=>({}));
   if (!id) return json(req, { error: 'id-required' }, 400);
+
+  const matches = await sql`
+    SELECT id, date_iso, a1, a2, b1, b2, court_name, court_email, calendar_sent, finalizado
+    FROM matches WHERE id=${id}
+  `;
+  if (matches.length === 0) return json(req, { error: 'not-found' }, 404);
+  const match = matches[0];
+
+  const shouldNotifyCancel = !match.finalizado && match.calendar_sent;
+  let cancelError = null;
+  if (shouldNotifyCancel) {
+    const playerIds = [match.a1, match.a2, match.b1, match.b2].filter(Boolean);
+    const players = playerIds.length
+      ? await sql`SELECT id, name, email FROM players WHERE id = ANY(${playerIds})`
+      : [];
+    const participantEmails = players.filter(p=>p.email).map(p=>p.email);
+    const participantNames = players.map(p=>p.name).filter(Boolean);
+    const namesText = participantNames.length ? formatHumanList(participantNames) : 'los participantes';
+    const { date, time } = formatDateParts(match.date_iso);
+    const body = `Se cancela el partido para el día ${date} a la hora ${time} que jugabas con ${namesText} en la pista ${match.court_name || 'pendiente'}.`;
+
+    const recipients = participantEmails.slice();
+    const hasCourt = !!match.court_email;
+    let to = '';
+    let cc = [];
+    if (hasCourt) {
+      to = match.court_email;
+      cc = recipients;
+    } else if (recipients.length) {
+      to = recipients[0];
+      cc = recipients.slice(1);
+    }
+
+    if (to) {
+      try {
+        await sendMail({
+          to,
+          cc,
+          subject: `Cancelación partido ${date}`,
+          text: body,
+        });
+      } catch (err) {
+        cancelError = err;
+      }
+    }
+  }
+
+  if (cancelError) return json(req, { error: 'cancel-mail-failed', details: String(cancelError.message || cancelError) }, 502);
 
   await sql`DELETE FROM matches WHERE id=${id}`;
   return json(req, { ok: true });

--- a/netlify/functions/list-matches.js
+++ b/netlify/functions/list-matches.js
@@ -6,7 +6,8 @@ export default async (req) => {
   const rows = await sql`
     SELECT id, date_iso, a1, a2, b1, b2, sets_a, sets_b,
            s1a, s1b, s2a, s2b, s3a, s3b,
-           finalizado, comment, photo_base64
+           finalizado, comment, photo_base64,
+           court_name, court_email, reservation_sent, calendar_sent
     FROM matches
     ORDER BY COALESCE(date_iso,'') DESC, id DESC`;
   return json(req, rows);

--- a/netlify/functions/list-players.js
+++ b/netlify/functions/list-players.js
@@ -6,7 +6,7 @@ export default async (req) => {
   const p = preflight(req); if (p) return p;
   try {
     const rows = await sql`
-      SELECT id, name, alias, photo_base64
+      SELECT id, name, alias, photo_base64, email
       FROM players
       ORDER BY name ASC
     `;

--- a/netlify/functions/migrate.js
+++ b/netlify/functions/migrate.js
@@ -29,7 +29,19 @@ export async function handler(event) {
     // Añadir columnas por si venís de un esquema anterior
     await sql`ALTER TABLE players ADD COLUMN IF NOT EXISTS alias TEXT`;
     await sql`ALTER TABLE players ADD COLUMN IF NOT EXISTS photo_base64 TEXT`;
+    await sql`ALTER TABLE players ADD COLUMN IF NOT EXISTS email TEXT`;
+
     await sql`ALTER TABLE matches ADD COLUMN IF NOT EXISTS photo_base64 TEXT`;
+    await sql`ALTER TABLE matches ADD COLUMN IF NOT EXISTS sets_a INT`;
+    await sql`ALTER TABLE matches ADD COLUMN IF NOT EXISTS sets_b INT`;
+    await sql`ALTER TABLE matches ADD COLUMN IF NOT EXISTS court_name TEXT`;
+    await sql`ALTER TABLE matches ADD COLUMN IF NOT EXISTS court_email TEXT`;
+    await sql`ALTER TABLE matches ADD COLUMN IF NOT EXISTS reservation_sent BOOLEAN DEFAULT FALSE`;
+    await sql`ALTER TABLE matches ADD COLUMN IF NOT EXISTS calendar_sent BOOLEAN DEFAULT FALSE`;
+    await sql`ALTER TABLE matches ALTER COLUMN reservation_sent SET DEFAULT FALSE`;
+    await sql`ALTER TABLE matches ALTER COLUMN calendar_sent SET DEFAULT FALSE`;
+    await sql`UPDATE matches SET reservation_sent=false WHERE reservation_sent IS NULL`;
+    await sql`UPDATE matches SET calendar_sent=false WHERE calendar_sent IS NULL`;
 
     return json({ ok: true });
   } catch (err) {

--- a/netlify/functions/send-calendar.js
+++ b/netlify/functions/send-calendar.js
@@ -1,0 +1,71 @@
+import { sql } from './_common/db.js';
+import { json, preflight, requireAuth } from './_common/http.js';
+import { sendMail, formatICS } from './_common/email.js';
+import { formatDateParts, formatHumanList } from './_common/format.js';
+
+const ninetyMinutes = 90 * 60 * 1000;
+
+export default async (req) => {
+  const p = preflight(req); if (p) return p;
+  if (!requireAuth(req)) return json(req, { error: 'unauthorized' }, 401);
+
+  const body = await req.json().catch(()=>({}));
+  const matchId = body.matchId;
+  if (!matchId) return json(req, { error: 'match-required' }, 400);
+
+  const rows = await sql`
+    SELECT id, date_iso, a1, a2, b1, b2, court_name, calendar_sent, finalizado
+    FROM matches WHERE id=${matchId}
+  `;
+  if (!rows.length) return json(req, { error: 'not-found' }, 404);
+  const match = rows[0];
+  if (match.finalizado) return json(req, { error: 'already-finalized' }, 400);
+
+  const playerIds = [match.a1, match.a2, match.b1, match.b2].filter(Boolean);
+  const players = playerIds.length
+    ? await sql`SELECT id, name, email FROM players WHERE id = ANY(${playerIds})`
+    : [];
+  const attendees = players.filter(p=>p.email).map(p=>({ name: p.name, email: p.email }));
+  if (!attendees.length) return json(req, { error: 'no-recipients' }, 400);
+
+  const { date, time } = formatDateParts(match.date_iso);
+  const namesText = formatHumanList(players.map(p=>p.name));
+  const start = match.date_iso ? new Date(match.date_iso) : new Date();
+  const end = new Date(start.getTime() + ninetyMinutes);
+  const organizerEmail = process.env.SMTP_FROM || process.env.MAIL_FROM || 'julio@gepgroup.es';
+  const summary = `GEP Padel + ${match.court_name || 'Pista por confirmar'}`;
+  const description = `Partido en ${match.court_name || 'pista por confirmar'} el ${date} a las ${time}. Participantes: ${namesText}.`;
+  const icsContent = formatICS({
+    id: match.id,
+    summary,
+    description,
+    location: match.court_name || '',
+    start,
+    end,
+    organizer: { name: 'Julio de GEP', email: organizerEmail },
+    attendees,
+  });
+
+  const text = `Hola!
+
+Adjunto la invitación de calendario para el partido en ${match.court_name || 'pista por confirmar'} el ${date} a las ${time}.
+Participantes: ${namesText}.
+`;
+
+  await sendMail({
+    to: attendees[0].email,
+    cc: attendees.slice(1).map(a=>a.email),
+    subject: summary,
+    text,
+    attachments: [
+      {
+        filename: 'gep-padel.ics',
+        content: icsContent,
+        contentType: 'text/calendar; method=REQUEST; charset="utf-8"'
+      }
+    ]
+  });
+
+  await sql`UPDATE matches SET calendar_sent=true WHERE id=${matchId}`;
+  return json(req, { ok: true, calendar_sent: true });
+};

--- a/netlify/functions/send-reservation.js
+++ b/netlify/functions/send-reservation.js
@@ -1,0 +1,41 @@
+import { sql } from './_common/db.js';
+import { json, preflight, requireAuth } from './_common/http.js';
+import { sendMail } from './_common/email.js';
+import { formatDateParts } from './_common/format.js';
+
+export default async (req) => {
+  const p = preflight(req); if (p) return p;
+  if (!requireAuth(req)) return json(req, { error: 'unauthorized' }, 401);
+
+  const body = await req.json().catch(()=>({}));
+  const matchId = body.matchId;
+  const message = (body.message || '').trim();
+  if (!matchId) return json(req, { error: 'match-required' }, 400);
+  if (!message) return json(req, { error: 'message-required' }, 400);
+
+  const rows = await sql`
+    SELECT id, date_iso, a1, a2, b1, b2, court_name, court_email
+    FROM matches WHERE id=${matchId}
+  `;
+  if (!rows.length) return json(req, { error: 'not-found' }, 404);
+  const match = rows[0];
+  if (!match.court_email) return json(req, { error: 'court-email-missing' }, 400);
+
+  const playerIds = [match.a1, match.a2, match.b1, match.b2].filter(Boolean);
+  const players = playerIds.length
+    ? await sql`SELECT id, name, email FROM players WHERE id = ANY(${playerIds})`
+    : [];
+  const participantEmails = players.filter(p=>p.email).map(p=>p.email);
+  const { date, time } = formatDateParts(match.date_iso);
+  const subject = `Reserva pista ${match.court_name || ''} - ${date} ${time}`.trim();
+
+  await sendMail({
+    to: match.court_email,
+    cc: participantEmails,
+    subject,
+    text: message,
+  });
+
+  await sql`UPDATE matches SET reservation_sent=true WHERE id=${matchId}`;
+  return json(req, { ok: true, reservation_sent: true });
+};

--- a/public/index.html
+++ b/public/index.html
@@ -40,12 +40,31 @@
 
     // ---------------- Utils ----------------
     const AVA_FALLBACK = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAALElEQVQokWP8//8/AyWYgQEDYwMDA2EQJgZoYQxUM0GMg0GG0wGJQGgYAAAUyQJ0T+eG9wAAAABJRU5ErkJggg==';
+    const COURTS = [
+      { id:'padel1', name:'Padel 1 Sabadell', email:'info@padel1.com' },
+      { id:'test', name:'Pista Test', email:'julio@gepgroup.es' },
+    ];
+    const escAttr = (v='') => String(v).replace(/&/g,'&amp;').replace(/"/g,'&quot;');
 
     function miniAvatar(ph,name){
       const src = ph || '/icon-192.png';
       return `<img class="avatar" src="${src}" onerror="this.src='${AVA_FALLBACK}'" alt="${name||''}" />`;
     }
     const formatDT = iso => iso ? new Date(iso).toLocaleString() : 'Sin fecha';
+    const formatDateParts = (iso) => {
+      if (!iso) {
+        const now = new Date();
+        return {
+          date: now.toLocaleDateString('es-ES', { weekday:'long', year:'numeric', month:'long', day:'numeric' }),
+          time: now.toLocaleTimeString('es-ES', { hour:'2-digit', minute:'2-digit' })
+        };
+      }
+      const d = new Date(iso);
+      return {
+        date: d.toLocaleDateString('es-ES', { weekday:'long', year:'numeric', month:'long', day:'numeric' }),
+        time: d.toLocaleTimeString('es-ES', { hour:'2-digit', minute:'2-digit' })
+      };
+    };
 
     async function compressImage(file, maxW = 1200, quality = 0.85){
       const img = new Image();
@@ -69,6 +88,51 @@
       btn.innerHTML = `<img src="./icon-192.png" class="h-5 w-5 animate-spin mx-auto" alt="">`;
       try { return await task(); }
       finally { btn.disabled = false; btn.style.width=''; btn.innerHTML = html; }
+    }
+
+    const parseError = (err) => {
+      if (!err) return 'Error desconocido';
+      const raw = err.message || err.toString();
+      try {
+        const data = JSON.parse(raw);
+        if (data && data.error) return data.error;
+      } catch (_) {}
+      return raw || 'Error desconocido';
+    };
+
+    function openTextModal({ title, defaultValue, confirmLabel = 'Enviar' }) {
+      return new Promise((resolve) => {
+        const modal = T(`
+          <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+            <div class="bg-white rounded-2xl shadow-xl w-full max-w-xl p-5 grid gap-3">
+              <h3 class="text-lg font-semibold">${title}</h3>
+              <textarea class="border rounded-xl px-3 py-2 min-h-[180px]" data-modal-text></textarea>
+              <div class="flex justify-end gap-2">
+                <button type="button" class="btn-soft" data-modal-cancel>Cancelar</button>
+                <button type="button" class="btn-dark" data-modal-ok>${confirmLabel}</button>
+              </div>
+            </div>
+          </div>`);
+        const textarea = modal.querySelector('[data-modal-text]');
+        textarea.value = defaultValue || '';
+        const onKey = (ev) => {
+          if (ev.key === 'Escape') {
+            ev.preventDefault();
+            cleanup(null);
+          }
+        };
+        const cleanup = (val) => {
+          document.removeEventListener('keydown', onKey);
+          modal.remove();
+          resolve(val);
+        };
+        modal.querySelector('[data-modal-cancel]').onclick = () => cleanup(null);
+        modal.querySelector('[data-modal-ok]').onclick = () => cleanup(textarea.value.trim());
+        modal.addEventListener('click', (ev) => { if (ev.target === modal) cleanup(null); });
+        document.addEventListener('keydown', onKey);
+        document.body.appendChild(modal);
+        setTimeout(()=>textarea.focus(), 30);
+      });
     }
 
     async function loadAll(){
@@ -194,11 +258,16 @@
       root.appendChild(T(`<div class="mt-8"></div>`));
 
       // ------ Crear partido ------
+      const courtOptions = COURTS.map(c=>`<option value="${c.id}">${c.name}</option>`).join('');
       const sec=T(`<section class="mb-6 grid gap-4">
         <div class="rounded-2xl border border-neutral-200 bg-white p-4">
           <h3 class="font-semibold mb-3">Crear Nuevo Partido</h3>
           <div class="grid md:grid-cols-2 gap-3">
             <input id="fecha" type="datetime-local" class="px-3 py-2 rounded-xl border border-neutral-300" />
+            <select id="court" class="px-3 py-2 rounded-xl border border-neutral-300">
+              <option value="">Selecciona pista</option>
+              ${courtOptions}
+            </select>
           </div>
           <div class="grid md:grid-cols-2 gap-3 mt-3">
             <div><div class="text-sm text-neutral-500 mb-1">Equipo A (2 jugadores)</div><div id="teamA" class="grid grid-cols-2 gap-2"></div></div>
@@ -231,15 +300,24 @@
         teamA.appendChild(a); teamB.appendChild(b);
       });
 
-      sec.querySelector("#createMatch").onclick=(e)=>spin(e.currentTarget, async ()=>{
+      sec.querySelector("#createMatch").onclick=async (ev)=>{
         if(!canEdit) return alert("Introduce la clave de edición.");
         if(selA.size!==2 || selB.size!==2) return alert("Cada equipo debe tener 2 jugadores.");
+        const courtSel = sec.querySelector("#court");
+        const court = COURTS.find(c=>c.id===courtSel.value);
+        if(!court) return alert("Selecciona una pista.");
         const fecha=sec.querySelector("#fecha").value || new Date().toISOString();
         const coment=sec.querySelector("#coment").value.trim();
         const [a1,a2]=[...selA], [b1,b2]=[...selB];
-        await API.post('/.netlify/functions/create-match',{dateISO:fecha,a1,a2,b1,b2,comment:coment});
-        await init();
-      });
+        try {
+          await spin(ev.currentTarget, async ()=>{
+            await API.post('/.netlify/functions/create-match',{dateISO:fecha,a1,a2,b1,b2,comment:coment,court_name:court.name,court_email:court.email});
+          });
+          await init();
+        } catch(err) {
+          alert(`No se pudo crear el partido: ${parseError(err)}`);
+        }
+      };
 
       // -------- Histórico de partidos --------
       root.appendChild(T(`<h3 class="text-lg font-semibold mt-6 mb-2">Histórico de partidos</h3>`));
@@ -299,6 +377,19 @@
             </div>
 
             <div class="grid gap-2">
+              <div class="text-sm text-neutral-600">
+                ${m.court_name
+                  ? `<span class="font-medium">Pista:</span> ${m.court_name}${m.court_email?` • <a class="text-blue-600 hover:underline" href="mailto:${m.court_email}">${m.court_email}</a>`:''}`
+                  : '<span class="text-amber-600 font-medium">Pista pendiente de asignar</span>'}
+              </div>
+              ${(!m.finalizado && m.reservation_sent)?`<div class="text-xs font-medium text-emerald-600">Reserva Pista Enviada</div>`:''}
+              ${(!m.finalizado && m.calendar_sent)?`<div class="text-xs font-medium text-sky-600">Invitaciones enviadas</div>`:''}
+              ${!m.finalizado ? `
+                <div class="flex flex-wrap gap-2">
+                  <button class="btn-soft" id="reserve-${m.id}">Reservar</button>
+                  <button class="btn-soft" id="calendar-${m.id}">Enviar Calendar</button>
+                </div>
+              `:''}
               ${m.photo_base64?`<img src="${m.photo_base64}" class="rounded-xl border max-w-[420px] max-h-[240px] object-cover"/>`:''}
               ${!m.finalizado ? `
                 <div class="flex items-center gap-2">
@@ -310,6 +401,58 @@
             </div>
           </div>
         </div>`);
+
+        const reserveBtn = card.querySelector(`#reserve-${m.id}`);
+        if(reserveBtn){
+          reserveBtn.onclick=async (ev)=>{
+            if(!canEdit) return alert("Introduce la clave de edición.");
+            if(!m.court_email){
+              alert('No hay correo de pista configurado.');
+              return;
+            }
+            const { date, time } = formatDateParts(m.date_iso);
+            const defaultMsg = `¡Hola!\n\nNos gustaría reservar una pista para el día ${date} y la hora ${time}.\nSi tenéis espacio, nos podrías confirmar el número de pista por favor.\nLa reserva la ponemos a nombre de Julio de GEP (es el nombre de la empresa)\n\nMuchas gracias por adelantado.`;
+            const message = await openTextModal({ title: 'Correo de reserva', defaultValue: defaultMsg, confirmLabel: 'Enviar correo' });
+            if(!message) return;
+            try {
+              await spin(ev.currentTarget, async ()=>{
+                await API.post('/.netlify/functions/send-reservation',{ matchId:m.id, message });
+              });
+              alert('Correo enviado ✅');
+              await init();
+            } catch(err) {
+              alert(`No se pudo enviar el correo: ${parseError(err)}`);
+            }
+          };
+        }
+
+        const calendarBtn = card.querySelector(`#calendar-${m.id}`);
+        if(calendarBtn){
+          calendarBtn.onclick=async (ev)=>{
+            if(!canEdit) return alert("Introduce la clave de edición.");
+            const emailPlayers=[a1,a2,b1,b2].map(P).filter(p=>p && p.email);
+            if(emailPlayers.length===0){
+              alert('Ningún participante tiene email configurado.');
+              return;
+            }
+            if(!m.reservation_sent){
+              const ok = confirm('¿Tenéis la pista reservada ya?');
+              if(!ok){
+                alert('No se enviará hasta que no haya pista.');
+                return;
+              }
+            }
+            try {
+              await spin(ev.currentTarget, async ()=>{
+                await API.post('/.netlify/functions/send-calendar',{ matchId:m.id });
+              });
+              alert('Invitaciones enviadas ✅');
+              await init();
+            } catch(err) {
+              alert(`No se pudieron enviar las invitaciones: ${parseError(err)}`);
+            }
+          };
+        }
 
         // Subir foto
         const upBtn = card.querySelector(`#up-${m.id}`);
@@ -356,6 +499,7 @@
           <div class="flex flex-col md:flex-row gap-2">
             <input id="name" class="flex-1 px-3 py-2 rounded-xl border border-neutral-300" placeholder="Nombre y apellidos" />
             <input id="alias" class="flex-1 px-3 py-2 rounded-xl border border-neutral-300" placeholder="Alias (opcional)" />
+            <input id="email" type="email" class="flex-1 px-3 py-2 rounded-xl border border-neutral-300" placeholder="Email (opcional)" />
             <button id="add" class="${canEdit?'btn-dark':'btn-soft text-neutral-400'}">Añadir</button>
           </div>
         </div>
@@ -366,14 +510,21 @@
       </section>`);
       root.appendChild(secP);
 
-      secP.querySelector("#add").onclick=(e)=>spin(e.currentTarget, async()=>{
+      secP.querySelector("#add").onclick=async (ev)=>{
         if(!canEdit) return alert("Introduce la clave de edición.");
         const name=secP.querySelector("#name").value.trim();
         const alias=secP.querySelector("#alias").value.trim();
+        const email=secP.querySelector("#email").value.trim();
         if(!name) return;
-        await API.post('/.netlify/functions/add-player',{name,alias});
-        await init();
-      });
+        try {
+          await spin(ev.currentTarget, async()=>{
+            await API.post('/.netlify/functions/add-player',{name,alias,email});
+          });
+          await init();
+        } catch(err) {
+          alert(`No se pudo añadir el jugador: ${parseError(err)}`);
+        }
+      };
 
       const plist=secP.querySelector("#plist");
       players.forEach(j=>{
@@ -383,25 +534,45 @@
           <div>
             <div class="font-medium">${j.name}</div>
             ${j.alias? `<div class="text-sm text-neutral-500">Alias: ${j.alias}</div>`:''}
+            ${j.email? `<div class="text-sm text-neutral-500">Email: ${j.email}</div>`:''}
             <div class="mt-2 flex flex-wrap items-center gap-2 ${canEdit?'':'opacity-50 pointer-events-none'}">
               <input type="text" class="px-2 py-1 rounded-lg border" placeholder="Nuevo nombre" id="nn-${j.id}">
               <input type="text" class="px-2 py-1 rounded-lg border" placeholder="Nuevo alias" id="na-${j.id}">
+              <input type="email" class="px-2 py-1 rounded-lg border" placeholder="Nuevo email" id="ne-${j.id}" value="${escAttr(j.email||'')}">
               <input type="file" accept="image/*" id="np-${j.id}">
               <button class="btn-soft" id="save-${j.id}">Guardar cambios</button>
             </div>
           </div>
           <button data-id="${j.id}" class="text-sm btn-soft">Eliminar</button>
         </li>`);
-        row.querySelector(`#save-${j.id}`).onclick=(e)=>spin(e.currentTarget, async()=>{
+        row.querySelector(`#save-${j.id}`).onclick=async (ev)=>{
           if(!canEdit) return;
           const name=row.querySelector(`#nn-${j.id}`).value.trim();
           const alias=row.querySelector(`#na-${j.id}`).value.trim();
+          const emailInput=row.querySelector(`#ne-${j.id}`);
+          const emailVal=emailInput?emailInput.value.trim():'';
+          const originalEmail=(j.email||'').trim();
           const f=row.querySelector(`#np-${j.id}`).files?.[0];
           let photo=null; if(f) photo=await compressImage(f, 900, 0.85);
-          await API.post('/.netlify/functions/update-player',{id:j.id, ...(name?{name}:{}) , ...(alias?{alias}:{}) , ...(photo?{photo_base64:photo}:{}) });
-          alert('Cambios guardados ✅');
-          await init();
-        });
+          const payload={ id:j.id };
+          if(name) payload.name=name;
+          if(alias) payload.alias=alias;
+          if(photo) payload.photo_base64=photo;
+          if(emailInput && emailVal!==originalEmail) payload.email=emailVal;
+          if(Object.keys(payload).length===1 && !payload.email){
+            alert('Introduce algún cambio antes de guardar.');
+            return;
+          }
+          try {
+            await spin(ev.currentTarget, async()=>{
+              await API.post('/.netlify/functions/update-player',payload);
+            });
+            alert('Cambios guardados ✅');
+            await init();
+          } catch(err) {
+            alert(`No se pudieron guardar los cambios: ${parseError(err)}`);
+          }
+        };
         row.querySelector("button[data-id]").onclick=(e)=>spin(e.currentTarget, async()=>{
           if(!canEdit) return alert("Introduce la clave de edición.");
           if(!confirm("Eliminar jugador/a?")) return;


### PR DESCRIPTION
## Summary
- add SMTP + ICS utilities and new Netlify functions to send reservation, calendar and cancellation emails
- extend player and match endpoints/schema with email, court and delivery state tracking
- update the dashboard UI to manage player emails, select courts on creation, and trigger reservation/calendar workflows with confirmations
- ensure the migration/auth guard accepts query keys and rely on database-generated IDs when inserting players and matches
- harden API key validation so Netlify functions accept the updated shared secret from headers, queries, raw bodies or comma/newline-separated environment values

## Testing
- API_SHARED_KEY="GEPtomic112, 'old-key'" DATABASE_URL="postgres://u:p@localhost/db" node --input-type=module <<'NODE' ... NODE

------
https://chatgpt.com/codex/tasks/task_e_68c878ea702c832897c5bac7ec6dc1bd