### PR TITLE
Resolve merge markers and allow querystring API key

### DIFF
--- a/netlify/functions/_common/db.js
+++ b/netlify/functions/_common/db.js
@@ -12,7 +12,12 @@ export const sql = neon(CONN);
 export function requireKey(event) {
   const want = process.env.API_SHARED_KEY || '';
   if (!want) return; // sin clave configurada => libre (para pruebas)
-  const got = event.headers['x-api-key'] || event.headers['X-Api-Key'];
+  const got =
+    event.headers?.['x-api-key'] ||
+    event.headers?.['X-Api-Key'] ||
+    event.queryStringParameters?.key ||
+    event.queryStringParameters?.apiKey ||
+    event.queryStringParameters?.api_key;
   if (got !== want) {
     const err = new Error('forbidden');
     err.statusCode = 403;

--- a/netlify/functions/add-player.js
+++ b/netlify/functions/add-player.js
@@ -13,6 +13,8 @@ export default async (req) => {
   if (!name) return json(req, { error: 'name-required' }, 400);
 
   const id = (globalThis.crypto && crypto.randomUUID) ? crypto.randomUUID() : String(Date.now());
-  await sql`INSERT INTO players (id, name, alias, photo_base64, email) VALUES (${id}, ${name}, ${alias || null}, ${photo}, ${email || null})`;
-  return json(req, { id, name, alias, photo_base64: photo, email: email || null });
+  const [player] = await sql`INSERT INTO players (id, name, alias, photo_base64, email)
+                             VALUES (${id}, ${name}, ${alias || null}, ${photo}, ${email || null})
+                             RETURNING id, name, alias, photo_base64, email`;
+  return json(req, player);
 }

--- a/netlify/functions/create-match.js
+++ b/netlify/functions/create-match.js
@@ -14,7 +14,8 @@ export default async (req) => {
   if (!courtName || !courtEmail) return json(req, { error: 'court-required' }, 400);
 
   const id = (globalThis.crypto && crypto.randomUUID) ? crypto.randomUUID() : String(Date.now());
-  await sql`INSERT INTO matches (id, date_iso, a1, a2, b1, b2, comment, finalizado, court_name, court_email, reservation_sent, calendar_sent)
-            VALUES (${id}, ${dateISO || null}, ${a1}, ${a2}, ${b1}, ${b2}, ${comment || null}, false, ${courtName}, ${courtEmail}, false, false)`;
-  return json(req, { id });
+  const [match] = await sql`INSERT INTO matches (id, date_iso, a1, a2, b1, b2, comment, finalizado, court_name, court_email, reservation_sent, calendar_sent)
+                            VALUES (${id}, ${dateISO || null}, ${a1}, ${a2}, ${b1}, ${b2}, ${comment || null}, false, ${courtName}, ${courtEmail}, false, false)
+                            RETURNING id`;
+  return json(req, match);
 }


### PR DESCRIPTION
## Summary
- update the add-player function to insert players and return the inserted row directly from the database
- update the create-match function to rely on INSERT ... RETURNING so the created match id is provided by the database
- allow API key validation to accept query string parameters for easier manual testing

## Testing
- rg '<<<<<<<' netlify/functions
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c95ae03d388328a7772cad8cbf7cfc