### PR TITLE
Enable match date editing alongside reservation actions

### DIFF
--- a/netlify/functions/update-match-date.js
+++ b/netlify/functions/update-match-date.js
@@ -1,0 +1,47 @@
+import { sql } from './_common/db.js';
+import { json, preflight, requireAuth } from './_common/http.js';
+
+const isLocalDateTime = (value) =>
+  typeof value === 'string' && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(value.trim());
+
+export default async (req) => {
+  const p = preflight(req); if (p) return p;
+  if (!requireAuth(req)) return json(req, { error: 'unauthorized' }, 401);
+
+  const body = await req.json().catch(() => ({}));
+  const { id } = body;
+  let { dateISO } = body;
+
+  if (!id) return json(req, { error: 'id-required' }, 400);
+
+  let normalized = null;
+  if (dateISO === null || dateISO === undefined || dateISO === '') {
+    normalized = null;
+  } else if (typeof dateISO === 'string') {
+    const trimmed = dateISO.trim();
+    if (!trimmed) {
+      normalized = null;
+    } else {
+      const parsed = new Date(trimmed);
+      if (Number.isNaN(parsed.getTime())) {
+        return json(req, { error: 'invalid-date' }, 400);
+      }
+      normalized = isLocalDateTime(trimmed) ? trimmed : parsed.toISOString();
+    }
+  } else {
+    return json(req, { error: 'invalid-date' }, 400);
+  }
+
+  const existing = await sql`SELECT id FROM matches WHERE id=${id} LIMIT 1`;
+  if (existing.length === 0) return json(req, { error: 'not-found' }, 404);
+
+  await sql`
+    UPDATE matches
+      SET date_iso=${normalized},
+          reservation_sent=false,
+          calendar_sent=false
+      WHERE id=${id}
+  `;
+
+  return json(req, { ok: true, date_iso: normalized });
+};

--- a/public/index.html
+++ b/public/index.html
@@ -66,6 +66,14 @@
       };
     };
 
+    const formatDateForInput = (iso) => {
+      if (!iso) return '';
+      const d = new Date(iso);
+      if (Number.isNaN(d.getTime())) return '';
+      const pad = (v) => String(v).padStart(2, '0');
+      return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+    };
+
     const isPastMatch = (iso) => {
       if (!iso) return false;
       const d = new Date(iso);
@@ -392,6 +400,16 @@
                   ? `<span class="font-medium">Pista:</span> ${courtName}${m.court_email?` • <a class="text-blue-600 hover:underline" href="mailto:${m.court_email}">${m.court_email}</a>`:''}`
                   : '<span class="text-amber-600 font-medium">Pista pendiente de asignar</span>'}
               </div>
+              ${(!m.finalizado && canEdit) ? `
+                <div class="grid gap-2">
+                  <label for="date-${m.id}" class="text-sm text-neutral-500">Fecha del partido</label>
+                  <div class="flex flex-wrap gap-2 items-center">
+                    <input type="datetime-local" id="date-${m.id}" class="px-3 py-2 rounded-xl border border-neutral-300" value="${formatDateForInput(m.date_iso)}">
+                    <button class="btn-soft" id="save-date-${m.id}">${m.date_iso ? 'Actualizar fecha' : 'Guardar fecha'}</button>
+                    ${m.date_iso ? `<button class="btn-soft" id="clear-date-${m.id}">Quitar fecha</button>`:''}
+                  </div>
+                </div>
+              `:''}
               ${isPast ? `<div class="text-xs text-neutral-500">Los envíos de correo están deshabilitados para partidos anteriores a hoy.</div>` : ''}
               ${(!m.finalizado && m.reservation_sent)?`<div class="text-xs font-medium text-emerald-600">Reserva Pista Enviada</div>`:''}
               ${(!m.finalizado && m.calendar_sent)?`<div class="text-xs font-medium text-sky-600">Invitaciones enviadas</div>`:''}
@@ -412,6 +430,52 @@
             </div>
           </div>
         </div>`);
+
+        const dateInput = card.querySelector(`#date-${m.id}`);
+        const saveDateBtn = card.querySelector(`#save-date-${m.id}`);
+        if(saveDateBtn){
+          saveDateBtn.onclick=async (ev)=>{
+            if(!canEdit) return alert("Introduce la clave de edición.");
+            if(!dateInput) return;
+            const value = (dateInput.value || '').trim();
+            if(!value){
+              alert('Introduce una fecha para guardar.');
+              dateInput.focus();
+              return;
+            }
+            if(Number.isNaN(new Date(value).getTime())){
+              alert('La fecha indicada no es válida.');
+              dateInput.focus();
+              return;
+            }
+            try {
+              await spin(ev.currentTarget, async ()=>{
+                await API.post('/.netlify/functions/update-match-date',{ id:m.id, dateISO:value });
+              });
+              alert('Fecha actualizada ✅');
+              await init();
+            } catch(err) {
+              alert(`No se pudo actualizar la fecha: ${parseError(err)}`);
+            }
+          };
+        }
+
+        const clearDateBtn = card.querySelector(`#clear-date-${m.id}`);
+        if(clearDateBtn){
+          clearDateBtn.onclick=async (ev)=>{
+            if(!canEdit) return alert("Introduce la clave de edición.");
+            if(!confirm('¿Quitar la fecha del partido?')) return;
+            try {
+              await spin(ev.currentTarget, async ()=>{
+                await API.post('/.netlify/functions/update-match-date',{ id:m.id, dateISO:null });
+              });
+              alert('Fecha eliminada ✅');
+              await init();
+            } catch(err) {
+              alert(`No se pudo actualizar la fecha: ${parseError(err)}`);
+            }
+          };
+        }
 
         const reserveBtn = card.querySelector(`#reserve-${m.id}`);
         if(reserveBtn){


### PR DESCRIPTION
## Summary
- add a Netlify function to update a match date resetting email flags
- extend the match card with date edit controls while keeping reservation/calendar actions

## Testing
- rg '<<<<<<<' public/index.html

------
https://chatgpt.com/codex/tasks/task_e_68c97c41ae608328980bb2d97c932db6