### PR TITLE
Show default standings sort indicator on points column

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -198,8 +198,8 @@
       root.appendChild(tableWrap);
 
       const sortState = {
-        ind: { key: null, dir: 'desc' },
-        pair: { key: null, dir: 'desc' },
+        ind: { key: 'puntos', dir: 'desc' },
+        pair: { key: 'puntos', dir: 'desc' },
       };
       const SORTABLE_COLUMNS = [
         { key: 'puntos', label: 'Puntos (sets)' },


### PR DESCRIPTION
## Summary
- default the standings sort state to the points column so the descending arrow is visible on load for both individual and pair views

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9bfcccdd08328b864c872a09ce612