### PR TITLE
Simplify match date display and remove court email link

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -669,8 +669,16 @@
         const isPast = isPastMatch(m.date_iso);
         const courtName = m.court_name || (isPast ? 'Padel 1 Sabadell' : '');
         const card=T(`<div class="rounded-2xl border border-neutral-200 bg-white p-4">
-          <div class="flex items-center justify-between text-sm mb-1">
-            <div class="text-neutral-500">${formatDT(m.date_iso)}</div>
+          <div class="flex flex-wrap items-start justify-between gap-3 text-sm mb-3">
+            <div class="grid gap-2">
+              <div class="text-neutral-500">${formatDT(m.date_iso)}</div>
+              ${(!m.finalizado && canEdit) ? `
+                <div class="flex flex-wrap gap-2 items-center">
+                  <input type="datetime-local" id="date-${m.id}" class="px-3 py-2 rounded-xl border border-neutral-300" value="${formatDateForInput(m.date_iso)}" aria-label="Fecha del partido">
+                  <button class="btn-soft" id="save-date-${m.id}">${m.date_iso ? 'Actualizar fecha' : 'Guardar fecha'}</button>
+                </div>
+              `:''}
+            </div>
             <div>${statusPill(m.finalizado)}</div>
           </div>
 
@@ -700,18 +708,9 @@
             <div class="grid gap-2">
               <div class="text-sm text-neutral-600">
                 ${courtName
-                  ? `<span class="font-medium">Pista:</span> ${courtName}${m.court_email?` • <a class="text-blue-600 hover:underline" href="mailto:${m.court_email}">${m.court_email}</a>`:''}`
+                  ? `<span class="font-medium">Pista:</span> ${courtName}${m.court_email?` • ${escAttr(m.court_email)}`:''}`
                   : '<span class="text-amber-600 font-medium">Pista pendiente de asignar</span>'}
               </div>
-              ${(!m.finalizado && canEdit) ? `
-                <div class="grid gap-2">
-                  <label for="date-${m.id}" class="text-sm text-neutral-500">Fecha del partido</label>
-                  <div class="flex flex-wrap gap-2 items-center">
-                    <input type="datetime-local" id="date-${m.id}" class="px-3 py-2 rounded-xl border border-neutral-300" value="${formatDateForInput(m.date_iso)}">
-                    <button class="btn-soft" id="save-date-${m.id}">${m.date_iso ? 'Actualizar fecha' : 'Guardar fecha'}</button>
-                  </div>
-                </div>
-              `:''}
               ${isPast ? `<div class="text-xs text-neutral-500">Los envíos de correo están deshabilitados para partidos anteriores a hoy.</div>` : ''}
               ${(!m.finalizado && m.reservation_sent)?`<div class="text-xs font-medium text-emerald-600">Reserva Pista Enviada</div>`:''}
               ${(!m.finalizado && m.calendar_sent)?`<div class="text-xs font-medium text-sky-600">Invitaciones enviadas</div>`:''}


### PR DESCRIPTION
## Summary
- show the match date editor next to the heading so the date only appears once on each card
- remove the duplicate date section above the reservation/calendar buttons
- render the court email as plain text instead of a mailto link

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c9cf71e84483289b8bb36feb236ca5