### PR TITLE
Update standings points calculation to new scoring rules

### DIFF
--- a/netlify/functions/standings.js
+++ b/netlify/functions/standings.js
@@ -18,6 +18,16 @@ const sumSetsGames = (m) => {
   return { sa, sb, ga, gb };
 };
 
+const matchPoints = (sa, sb) => {
+  if (sa > sb) {
+    return [sb === 0 ? 3 : 2, sb === 0 ? 0 : 1];
+  }
+  if (sb > sa) {
+    return [sa === 0 ? 0 : 1, sa === 0 ? 3 : 2];
+  }
+  return [0, 0];
+};
+
 export default async (req) => {
   const p = preflight(req); if (p) return p;
 
@@ -113,16 +123,18 @@ export default async (req) => {
     // PG/PP
     if (aWins) { A.forEach(id=>ind.get(id).pg++); B.forEach(id=>ind.get(id).pp++); }
     else if (bWins) { B.forEach(id=>ind.get(id).pg++); A.forEach(id=>ind.get(id).pp++); }
-    // Puntos (sets) + juegos ganados/perdidos
+    const [pointsA, pointsB] = matchPoints(sa, sb);
+
+    // Puntos + juegos ganados/perdidos
     A.forEach(id=>{
       const r = ind.get(id);
-      r.puntos += sa;
+      r.puntos += pointsA;
       r.jg += ga;
       r.jp += gb;
     });
     B.forEach(id=>{
       const r = ind.get(id);
-      r.puntos += sb;
+      r.puntos += pointsB;
       r.jg += gb;
       r.jp += ga;
     });
@@ -130,7 +142,7 @@ export default async (req) => {
     // Parejas stats
     if (pairA) {
       pairA.pj++;
-      pairA.puntos+=sa;
+      pairA.puntos+=pointsA;
       pairA.jg+=ga;
       pairA.jp+=gb;
       if (aWins) pairA.pg++;
@@ -138,7 +150,7 @@ export default async (req) => {
     }
     if (pairB) {
       pairB.pj++;
-      pairB.puntos+=sb;
+      pairB.puntos+=pointsB;
       pairB.jg+=gb;
       pairB.jp+=ga;
       if (bWins) pairB.pg++;

--- a/public/index.html
+++ b/public/index.html
@@ -341,7 +341,7 @@
         pair: { key: 'puntos', dir: 'desc' },
       };
       const SORTABLE_COLUMNS = [
-        { key: 'puntos', label: 'Puntos (sets)' },
+        { key: 'puntos', label: 'Puntos' },
         { key: 'pj', label: 'PJ' },
         { key: 'pg', label: 'PG' },
         { key: 'pp', label: 'PP' },


### PR DESCRIPTION
## Summary
- award standings points based on the new 3/0 and 2/1 scoring rules when processing match results
- rename the standings column header to "Puntos" to match the new scoring terminology

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e670ed7e648328ac08d690a68af7ef